### PR TITLE
Add Upstream Issue as a Related Link

### DIFF
--- a/internal/jira/cloner.go
+++ b/internal/jira/cloner.go
@@ -116,7 +116,7 @@ func Clone(issue *github.Issue, opts ...Option) (*gojira.Issue, error) {
 			// Reporter: &gojira.User{
 			//     Name: "youruser",
 			// },
-			Description: fmt.Sprintf("%s\n\nUpstream Github issue: %s\n", issue.GetBody(), getWebURL(issue.GetURL())),
+			Description: fmt.Sprintf("%s", issue.GetBody()),
 			Type: gojira.IssueType{
 				Name: "Story",
 			},
@@ -149,6 +149,16 @@ func Clone(issue *github.Issue, opts ...Option) (*gojira.Issue, error) {
 		if daIssue != nil {
 			fmt.Printf("Issue cloned; see %s\n",
 				fmt.Sprintf(config.jiraBaseURL+"browse/%s", daIssue.Key))
+
+			// Add remote link to the upstream issue
+			if _, _, err = jiraClient.Issue.AddRemoteLink(daIssue.ID, &gojira.RemoteLink{
+				Object: &gojira.RemoteLinkObject{
+					URL:   getWebURL(issue.GetURL()),
+					Title: fmt.Sprintf("Upstream Issue #%v", issue.GetNumber()),
+				},
+			}); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit updates the clone command to include the upstream issue url as a remoteLink as opposed to including it in the description body.

Looks like this:
<img width="1110" alt="image" src="https://github.com/oceanc80/gh2jira/assets/5481178/8ee46474-6c04-4af9-90ae-7ffd96dff591">
