### PR TITLE
Reconciler will identify state mismatches between linked gh/jira issues and print to console 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,19 @@ unit:
 vet:
 	$(GO) vet ./...
 
+.PHONY: fmt
+fmt:
+	$(GO) fmt ./...
+
 .PHONY: lint
 lint:
-	find . -name '*.go' | xargs goimports -w
+	find . -type f -name '*.go' | xargs gosimports -w -local $(shell go list -m)
 
 .PHONY: clean
 clean:
 	@rm -rf $(OBJ) coverage.out
+
+.PHONY: sanity
+sanity: fmt vet lint
+	git diff --exit-code
 

--- a/cmd/github/cmd.go
+++ b/cmd/github/cmd.go
@@ -12,8 +12,8 @@
 package github
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/oceanc80/gh2jira/cmd/github/list"
+	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {

--- a/cmd/github/cmd.go
+++ b/cmd/github/cmd.go
@@ -12,8 +12,9 @@
 package github
 
 import (
-	"github.com/oceanc80/gh2jira/cmd/github/list"
 	"github.com/spf13/cobra"
+
+	"github.com/oceanc80/gh2jira/cmd/github/list"
 )
 
 func NewCmd() *cobra.Command {

--- a/cmd/jira/list/list.go
+++ b/cmd/jira/list/list.go
@@ -15,10 +15,11 @@ package list
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/oceanc80/gh2jira/internal/config"
 	"github.com/oceanc80/gh2jira/internal/jira"
 	"github.com/oceanc80/gh2jira/pkg/util"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/jira/list/list.go
+++ b/cmd/jira/list/list.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	gojira "github.com/andygrunwald/go-jira"
 	"github.com/oceanc80/gh2jira/internal/config"
 	"github.com/oceanc80/gh2jira/internal/jira"
 	"github.com/oceanc80/gh2jira/pkg/util"
@@ -68,9 +69,19 @@ func NewCmd() *cobra.Command {
 			}
 			jql += " and status != Closed"
 
-			_, err = jc.GetIssues(jql)
+			var result []gojira.Issue
+			result, err = jc.SearchIssues(jql)
 			if err != nil {
 				return err
+			}
+			for _, i := range result {
+				fmt.Printf("%s (%s/%s): %+v -> %s\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary, i.Fields.Status.Name)
+				if i.Fields.Assignee != nil {
+					fmt.Printf("Assignee : %v\n", i.Fields.Assignee.DisplayName)
+				} else {
+					fmt.Printf("Assignee : Unassigned\n")
+				}
+				fmt.Printf("Reporter: %v\n", i.Fields.Reporter.DisplayName)
 			}
 
 			return nil

--- a/cmd/root/cmd.go
+++ b/cmd/root/cmd.go
@@ -44,6 +44,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(github.NewCmd())
 	cmd.AddCommand(jira.NewCmd())
 	cmd.AddCommand(clone.NewCmd())
+	cmd.AddCommand(NewReconcileCmd())
 
 	cmd.PersistentFlags().StringVar(&tokensFile, "token-file", defaultTokensFile, "file containing authentication tokens, if different than profile")
 	cmd.PersistentFlags().StringVar(&profilesFile, "profiles-file", defaultProfilesFile, "filename containing optional profile attributes")

--- a/cmd/root/reconcile.go
+++ b/cmd/root/reconcile.go
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package root
+
+import (
+	"fmt"
+
+	"github.com/oceanc80/gh2jira/internal/config"
+	"github.com/oceanc80/gh2jira/internal/gh"
+	"github.com/oceanc80/gh2jira/internal/jira"
+	"github.com/oceanc80/gh2jira/internal/reconcile"
+	"github.com/oceanc80/gh2jira/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func NewReconcileCmd() *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:   "reconcile",
+		Short: "reconcile github and jira issues",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ff, err := util.NewFlagFeeder(cmd)
+			if err != nil {
+				return err
+			}
+
+			config := config.NewConfig(ff)
+			err = config.Read()
+			if err != nil {
+				return err
+			}
+
+			if config.JiraProject == "" {
+				return fmt.Errorf("must specify jira project")
+			}
+			jql := fmt.Sprintf("project=%s and status != Closed", config.JiraProject)
+
+			gc, err := gh.NewConnection(gh.WithContext(cmd.Context()), gh.WithToken(config.Tokens.GithubToken))
+			if err != nil {
+				return err
+			}
+			err = gc.Connect()
+			if err != nil {
+				return err
+			}
+
+			jc, err := jira.NewConnection(
+				jira.WithBaseURI(config.JiraBaseUrl),
+				jira.WithAuthToken(config.Tokens.JiraToken),
+			)
+			if err != nil {
+				return err
+			}
+
+			err = jc.Connect()
+			if err != nil {
+				return err
+			}
+
+			err = reconcile.Reconcile(cmd.Context(), jql, jc, gc)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return runCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/oceanc80/gh2jira
 
-go 1.21.8
+go 1.21
+
+toolchain go1.21.8
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0
 	github.com/google/go-github/v47 v47.0.1-0.20220915193316-d6115619cf61
+	github.com/google/go-github/v60 v60.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/migueleliasweb/go-github-mock v0.0.12
 	github.com/onsi/ginkgo v1.16.5
@@ -21,7 +24,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,14 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-github/v47 v47.0.1-0.20220915193316-d6115619cf61 h1:NwwjLUXsMde3U2fY7aqRqkQPZHsE0XVBXgTLI2cwNQY=
 github.com/google/go-github/v47 v47.0.1-0.20220915193316-d6115619cf61/go.mod h1:VPZBXNbFSJGjyjFRUKo9vZGawTajnWzC/YjGw/oFKi0=
+github.com/google/go-github/v60 v60.0.0 h1:oLG98PsLauFvvu4D/YPxq374jhSxFYdzQGNCyONLfn8=
+github.com/google/go-github/v60 v60.0.0/go.mod h1:ByhX2dP9XT9o/ll2yXAu2VD8l5eNVg8hD4Cr0S/LmQk=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,8 +15,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/oceanc80/gh2jira/pkg/util"
 	"github.com/stretchr/testify/require"
+
+	"github.com/oceanc80/gh2jira/pkg/util"
 )
 
 var (

--- a/internal/gh/connection.go
+++ b/internal/gh/connection.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 	"golang.org/x/oauth2"
 )
 
@@ -25,9 +25,9 @@ type ConnectionOption func(*Connection) error
 
 type Connection struct {
 	transport *http.Client
-	client   *github.Client
-	token  string
-	ctx    context.Context
+	client    *github.Client
+	token     string
+	ctx       context.Context
 }
 
 // for unit testing
@@ -90,4 +90,3 @@ func (c *Connection) Connect() error {
 
 	return nil
 }
-

--- a/internal/gh/connection_test.go
+++ b/internal/gh/connection_test.go
@@ -2,7 +2,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/internal/gh/lister.go
+++ b/internal/gh/lister.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 )
 
 type ListSpec struct {

--- a/internal/gh/lister_test.go
+++ b/internal/gh/lister_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/gh/printer.go
+++ b/internal/gh/printer.go
@@ -15,7 +15,7 @@ package gh
 import (
 	"fmt"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 )
 
 const unassigned_issue string = "unassigned"

--- a/internal/gh/printer_test.go
+++ b/internal/gh/printer_test.go
@@ -17,7 +17,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/internal/gh/printer_test.go
+++ b/internal/gh/printer_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 
 	"github.com/google/go-github/v60/github"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/internal/jira/cloner.go
+++ b/internal/jira/cloner.go
@@ -37,7 +37,7 @@ func getDomainFromIssueUrl(url string) string {
 }
 
 func (conn *Connection) Clone(fromIssue *github.Issue, project string, dryRun bool) (*gojira.Issue, error) {
-	if conn.client == nil {
+	if conn.Client == nil {
 		// user attempted operation w/o connecting to remote first
 		if err := conn.Connect(); err != nil {
 			return nil, err
@@ -80,7 +80,7 @@ func (conn *Connection) Clone(fromIssue *github.Issue, project string, dryRun bo
 		fmt.Printf("Cloning issue #%d to jira project board: %s\n\n", fromIssue.GetNumber(), ji.Fields.Project.Key)
 		var err error
 
-		daIssue, response, err := conn.client.Issue.Create(&ji)
+		daIssue, response, err := conn.Client.Issue.Create(&ji)
 		if err != nil {
 			fmt.Printf("Error cloning issue: %v\n", err)
 			reqBody, ioerr := io.ReadAll(response.Response.Body)
@@ -95,7 +95,7 @@ func (conn *Connection) Clone(fromIssue *github.Issue, project string, dryRun bo
 				fmt.Sprintf(filepath.Join(conn.baseUri, "browse/%s"), daIssue.Key))
 		}
 		// Add remote link to the upstream issue
-		if _, _, err = conn.client.Issue.AddRemoteLink(daIssue.ID, &gojira.RemoteLink{
+		if _, _, err = conn.Client.Issue.AddRemoteLink(daIssue.ID, &gojira.RemoteLink{
 			Object: &gojira.RemoteLinkObject{
 				URL:   fromIssue.GetHTMLURL(),
 				Title: fmt.Sprintf("%s#%v", getDomainFromIssueUrl(fromIssue.GetHTMLURL()), fromIssue.GetNumber()),

--- a/internal/jira/cloner.go
+++ b/internal/jira/cloner.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	gojira "github.com/andygrunwald/go-jira"
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v60/github"
 )
 
 func getWebURL(url string) string {

--- a/internal/jira/connection.go
+++ b/internal/jira/connection.go
@@ -9,6 +9,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package jira
 
 import (
@@ -21,7 +22,7 @@ type ConnectionOption func(*Connection) error
 
 type Connection struct {
 	transport *gojira.BearerAuthTransport
-	client    *gojira.Client
+	Client    *gojira.Client
 	token     string
 	baseUri   string
 }
@@ -64,7 +65,7 @@ func (c *Connection) Connect() error {
 	if c.transport == nil {
 		return errors.New("transport is not set")
 	}
-	if c.client == nil {
+	if c.Client == nil {
 		gc, err := gojira.NewClient(c.transport.Client(), c.baseUri)
 		if err != nil {
 			return err
@@ -72,7 +73,7 @@ func (c *Connection) Connect() error {
 		if gc == nil {
 			return errors.New("unable to create github client")
 		}
-		c.client = gc
+		c.Client = gc
 	}
 	return nil
 }

--- a/internal/jira/printer.go
+++ b/internal/jira/printer.go
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jira
+
+import (
+	"context"
+	"fmt"
+
+	gojira "github.com/andygrunwald/go-jira"
+)
+
+func PrintJiraIssue(ctx context.Context, jc *Connection, jiraIssue gojira.Issue) {
+	fmt.Printf("%s (%s/%s): %+v -> %s\n", jiraIssue.Key, jiraIssue.Fields.Type.Name, jiraIssue.Fields.Priority.Name, jiraIssue.Fields.Summary, jiraIssue.Fields.Status.Name)
+	if jiraIssue.Fields.Assignee != nil {
+		fmt.Printf("\tAssignee : %v\n", jiraIssue.Fields.Assignee.DisplayName)
+	} else {
+		fmt.Printf("\tAssignee : Unassigned\n")
+	}
+	fmt.Printf("\tReporter: %v\n", jiraIssue.Fields.Reporter.DisplayName)
+	fmt.Printf("\tSummary: %s\n", jiraIssue.Fields.Summary)
+	rlinks, response, err := jc.Client.Issue.GetRemoteLinksWithContext(ctx, jiraIssue.Key)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+	fmt.Printf("\tLinks:\n")
+	for _, rlink := range *rlinks {
+		fmt.Printf("\t\t%s\n", rlink.Object.URL)
+	}
+	fmt.Println("")
+}
+
+func PrintJiraIssues(ctx context.Context, jc *Connection, jiraIssues []gojira.Issue) {
+	for _, ji := range jiraIssues {
+		PrintJiraIssue(ctx, jc, ji)
+	}
+}

--- a/internal/jira/search.go
+++ b/internal/jira/search.go
@@ -17,8 +17,8 @@ import (
 	gojira "github.com/andygrunwald/go-jira"
 )
 
-// getIssues will query Jira API using the provided JQL string
-func (c *Connection) GetIssues(jql string) ([]gojira.Issue, error) {
+// SearchIssues will query Jira API using the provided JQL string
+func (c *Connection) SearchIssues(jql string) ([]gojira.Issue, error) {
 
 	fmt.Printf("Querying Jira with JQL: %s\n", jql)
 
@@ -32,7 +32,7 @@ func (c *Connection) GetIssues(jql string) ([]gojira.Issue, error) {
 			MaxResults: 1000,      // Max amount
 			StartAt:    lastIssue, // Make sure we start grabbing issues from last checkpoint
 		}
-		issues, resp, err := c.client.Issue.Search(jql, opt)
+		issues, resp, err := c.Client.Issue.Search(jql, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -53,14 +53,5 @@ func (c *Connection) GetIssues(jql string) ([]gojira.Issue, error) {
 		}
 	}
 
-	for _, i := range result {
-		fmt.Printf("%s (%s/%s): %+v -> %s\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary, i.Fields.Status.Name)
-		if i.Fields.Assignee != nil {
-			fmt.Printf("Assignee : %v\n", i.Fields.Assignee.DisplayName)
-		} else {
-			fmt.Printf("Assignee : Unassigned\n")
-		}
-		fmt.Printf("Reporter: %v\n", i.Fields.Reporter.DisplayName)
-	}
 	return result, nil
 }

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,0 +1,134 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	gojira "github.com/andygrunwald/go-jira"
+	"github.com/oceanc80/gh2jira/internal/gh"
+	"github.com/oceanc80/gh2jira/internal/jira"
+	"github.com/oceanc80/gh2jira/internal/workflow"
+)
+
+const greenStart string = "\033[32m"
+const yellowStart string = "\033[33m"
+const redStart string = "\033[31m"
+const colorReset string = "\033[0m"
+
+func Reconcile(ctx context.Context, jql string, jc *jira.Connection, gc *gh.Connection) error {
+	if jc == nil || gc == nil {
+		return errors.New("nil connection")
+	}
+
+	// compile a regex to match github issue URLs
+	r, err := regexp.Compile(".*/github.com/.*/issues/([0-9]+)")
+	if err != nil {
+		return err
+	}
+
+	jiraIssues, err := jc.SearchIssues(jql)
+	if err != nil {
+		return err
+	}
+
+	// reduce the list to just those jira which have a github issue link
+	jiraIssues = slices.DeleteFunc(jiraIssues, func(issue gojira.Issue) bool {
+		rlinks, response, err := jc.Client.Issue.GetRemoteLinksWithContext(ctx, issue.Key)
+		if err != nil {
+			return false
+		}
+		defer response.Body.Close()
+		if rlinks != nil {
+			found := false
+			for _, rlink := range *rlinks {
+				if r.MatchString(rlink.Object.URL) {
+					found = true
+				}
+			}
+			return !found
+		}
+		return false
+	})
+
+	// jira.PrintJiraIssues(ctx, jc, jiraIssues)
+
+	err = workflow.ReadWorkflows()
+	if err != nil {
+		return err
+	}
+
+	// eval status of each jira and linked github issues for mismatch
+	for _, ji := range jiraIssues {
+		jstat := ji.Fields.Status.Name
+		rlinks, response, err := jc.Client.Issue.GetRemoteLinksWithContext(ctx, ji.Key)
+		if err != nil {
+			return err
+		}
+		defer response.Body.Close()
+		for _, rlink := range *rlinks {
+			if r.MatchString(rlink.Object.URL) {
+				project, issue, err := splitIssueRef(rlink.Object.URL)
+				if err != nil {
+					return err
+				}
+				// fmt.Printf("\tproject %q issue #%d\n", project, issue)
+				gi, err := gc.GetIssue(issue, gh.WithProject(project))
+				if err != nil {
+					return err
+				}
+				stateMatch, err := workflow.ValidateState(gi.GetState(), jstat)
+				if err != nil {
+					return err
+				}
+				if stateMatch {
+					fmt.Printf("%s%s/(%s/%d)%s status (g: %q\tj: %q)\t%sMATCH%s\n",
+						yellowStart, ji.Key, project, gi.GetNumber(), colorReset, gi.GetState(), jstat, greenStart, colorReset)
+				} else {
+					fmt.Printf("%s%s/(%s/%d)%s status (g: %q,\tj: %q)\t%sMISMATCH%s\n",
+						yellowStart, ji.Key, project, gi.GetNumber(), colorReset, gi.GetState(), jstat, redStart, colorReset)
+				}
+				// fmt.Printf("\tgithub issue #%d status %v\n", gi.GetNumber(), gi.GetState())
+			}
+		}
+	}
+
+	return nil
+}
+
+func splitIssueRef(ref string) (string, int, error) {
+	// split the ref into project (owner/repo), and issue number
+	s := strings.Split(ref, "/")
+	if len(s) <= 4 {
+		return "", 0, fmt.Errorf("unable to extract issue attributes from URL: %v", ref)
+	}
+
+	// URLs to this point have been manicured to follow the general schema
+	// https://www.github.com/(owner/repo)/issues/(num)
+	//       project...........^^^^^^^^^^
+	//       issue number..........................^^^
+	// split on '/', their offsets into the resulting slice are
+	//                         len(s)-4  len(s)-3  len(s)-1
+	project := fmt.Sprintf("%s/%s", s[len(s)-4], s[len(s)-3])
+	num, err := strconv.Atoi(s[len(s)-1])
+	if err != nil {
+		return "", 0, err
+	}
+
+	return project, num, nil
+}

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -1,0 +1,86 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workflow
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+type StateMapping struct {
+	GHState string   `json:"ghstate"`
+	JStates []string `json:"jstates"`
+}
+
+type Workflows struct {
+	Schema   string         `json:"schema"`
+	Name     string         `json:"name"`
+	Mappings []StateMapping `json:"mappings"`
+}
+
+var stateMappings map[string][]string
+
+const workflowfile string = "workflows.yaml"
+const defaultWorkflow string = "jira"
+const schemaName string = "gh2jira.workflows"
+
+func ReadWorkflows() error {
+	b, err := readFile(workflowfile)
+	if err != nil {
+		return err
+	}
+
+	var ws Workflows
+	err = yaml.Unmarshal(b, &ws)
+	if err != nil {
+		return err
+	}
+	if ws.Schema != schemaName {
+		return fmt.Errorf("invalid schema: %q should be %q", ws.Schema, schemaName)
+	}
+
+	stateMappings = make(map[string][]string)
+	if ws.Name == defaultWorkflow {
+		for _, m := range ws.Mappings {
+			stateMappings[m.GHState] = m.JStates
+		}
+	}
+
+	return nil
+}
+
+func ValidateState(ghstate string, jirastate string) (bool, error) {
+
+	if len(stateMappings) == 0 {
+		return false, fmt.Errorf("no state mappings found")
+	}
+
+	jstates, ok := stateMappings[ghstate]
+	if !ok {
+		return false, fmt.Errorf("no state mapping found for %q", ghstate)
+	}
+
+	for _, s := range jstates {
+		if s == jirastate {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// overrideable func for mocking os.ReadFile
+var readFile = func(file string) ([]byte, error) {
+	return os.ReadFile(file)
+}

--- a/workflows.yaml
+++ b/workflows.yaml
@@ -1,0 +1,11 @@
+schema: gh2jira.workflows
+name: jira
+mappings:
+  - ghstate: "open"
+    jstates:
+      - "To Do"
+      - "In Progress"
+      - "New"
+  - ghstate: "closed"
+    jstates:
+      - "Done"


### PR DESCRIPTION
example output:
![image](https://github.com/oceanc80/gh2jira/assets/86862637/cddf5162-7231-4293-bd78-6ee54b9f2d93)

resolves
- #15 
- #16 
- #17 
- #19 
