### PR TITLE
script-friendly structured output formats for reconcile

### DIFF
--- a/internal/jira/search.go
+++ b/internal/jira/search.go
@@ -12,15 +12,13 @@
 package jira
 
 import (
-	"fmt"
-
 	gojira "github.com/andygrunwald/go-jira"
 )
 
 // SearchIssues will query Jira API using the provided JQL string
 func (c *Connection) SearchIssues(jql string) ([]gojira.Issue, error) {
 
-	fmt.Printf("Querying Jira with JQL: %s\n", jql)
+	// fmt.Printf("Querying Jira with JQL: %s\n", jql)
 
 	// lastIssue is the index of the last issue returned
 	lastIssue := 0


### PR DESCRIPTION
new output formats.  default is still the ANSI-escaped terminal view, but with the `porcelain` option users may now select either json or yaml output formats. 

For e.g. json output for command
```shell
./gh2jira reconcile --profile-name 'operator sdk' --porcelain -o json
```
looks like
```json
[
  {
    "Jira": {
      "Name": "OPECO-3205",
      "Status": "To Do"
    },
    "Git": {
      "Name": "operator-framework/operator-controller/745",
      "Status": "open"
    },
    "Result": "MATCH"
  },
  {
    "Jira": {
      "Name": "OPECO-3204",
      "Status": "To Do"
    },
    "Git": {
      "Name": "operator-framework/operator-controller/742",
      "Status": "open"
    },
    "Result": "MATCH"
  },
  {
    "Jira": {
      "Name": "OPECO-3203",
      "Status": "To Do"
    },
    "Git": {
      "Name": "operator-framework/operator-controller/741",
      "Status": "open"
    },
    "Result": "MATCH"
  },
  {
    "Jira": {
      "Name": "OPECO-3165",
      "Status": "To Do"
    },
    "Git": {
      "Name": "operator-framework/operator-controller/663",
      "Status": "open"
    },
    "Result": "MATCH"
  }
]
```
